### PR TITLE
Halves Time to Create Holobarriers

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -72,7 +72,7 @@
 	desc = "A holographic projector that creates holographic security barriers."
 	icon_state = "signmaker_sec"
 	holosign_type = /obj/structure/holosign/barrier
-	creation_time = 30
+	creation_time = 15
 	max_signs = 6
 
 /obj/item/holosign_creator/engineering
@@ -80,7 +80,7 @@
 	desc = "A holographic projector that creates holographic engineering barriers."
 	icon_state = "signmaker_engi"
 	holosign_type = /obj/structure/holosign/barrier/engineering
-	creation_time = 30
+	creation_time = 15
 	max_signs = 6
 
 /obj/item/holosign_creator/atmos
@@ -96,7 +96,7 @@
 	desc = "A holographic projector that creates PENLITE holobarriers. Useful during quarantines since they halt those with malicious diseases."
 	icon_state = "signmaker_med"
 	holosign_type = /obj/structure/holosign/barrier/medical
-	creation_time = 30
+	creation_time = 15
 	max_signs = 3
 
 /obj/item/holosign_creator/cyborg

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -72,7 +72,7 @@
 	desc = "A holographic projector that creates holographic security barriers."
 	icon_state = "signmaker_sec"
 	holosign_type = /obj/structure/holosign/barrier
-	creation_time = 15
+	creation_time = 15 //ACULASTATION CHANGE
 	max_signs = 6
 
 /obj/item/holosign_creator/engineering
@@ -80,7 +80,7 @@
 	desc = "A holographic projector that creates holographic engineering barriers."
 	icon_state = "signmaker_engi"
 	holosign_type = /obj/structure/holosign/barrier/engineering
-	creation_time = 15
+	creation_time = 15 //ACULASTATION CHANGE
 	max_signs = 6
 
 /obj/item/holosign_creator/atmos
@@ -96,7 +96,7 @@
 	desc = "A holographic projector that creates PENLITE holobarriers. Useful during quarantines since they halt those with malicious diseases."
 	icon_state = "signmaker_med"
 	holosign_type = /obj/structure/holosign/barrier/medical
-	creation_time = 15
+	creation_time = 15 //ACULASTATION CHANGE
 	max_signs = 3
 
 /obj/item/holosign_creator/cyborg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes PENLITE, Security, and Engineering holobarriers take half the amount of time to create. Edit: as usual, my commit seems to be mistitled.

## Why It's Good For The Game

Balancewise, these aren't too powerful, as you can walk to get past them, or punch them a few times to destroy them. They're currently inconvenient to create, and dead weight in the security gear roster. This should make them more viable for use.

## Changelog
:cl:
add: Holobarriers take half the amount of time to create
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
