### PR TITLE
Make vended items go into hands if applicable.

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -786,9 +786,13 @@ GLOBAL_LIST_EMPTY(vending_products)
 			if(icon_vend) //Show the vending animation if needed
 				flick(icon_vend,src)
 			playsound(src, 'sound/machines/machine_vend.ogg', 50, TRUE, extrarange = -3)
-			new R.product_path(get_turf(src))
+			var/obj/item/vended_item = new R.product_path(get_turf(src))
 			R.amount--
-			. = TRUE
+			if(usr.CanReach(src) && usr.put_in_hands(vended_item))
+				to_chat(usr, "<span class='notice'>You take [R.name] out of the slot.</span>")
+			else
+				vended_item.forceMove(drop_location())
+				to_chat(usr, "<span class='warning'>[R.name] falls onto the floor!</span>")
 			SSblackbox.record_feedback("nested tally", "vending_machine_usage", 1, list("[type]", "[R.product_path]"))
 			vend_ready = TRUE
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -786,6 +786,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 			if(icon_vend) //Show the vending animation if needed
 				flick(icon_vend,src)
 			playsound(src, 'sound/machines/machine_vend.ogg', 50, TRUE, extrarange = -3)
+			/// ACULASTATION CHANGES START
 			var/obj/item/vended_item = new R.product_path(get_turf(src))
 			R.amount--
 			if(usr.CanReach(src) && usr.put_in_hands(vended_item))
@@ -793,6 +794,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 			else
 				vended_item.forceMove(drop_location())
 				to_chat(usr, "<span class='warning'>[R.name] falls onto the floor!</span>")
+			/// ACULASTATION CHANGES END
 			SSblackbox.record_feedback("nested tally", "vending_machine_usage", 1, list("[type]", "[R.product_path]"))
 			vend_ready = TRUE
 


### PR DESCRIPTION
## About The Pull Request

This PR simply makes vended items from vending machines go into any available empty hands. If there are no available hands then the item will simply drop on the same tile as the vending machine. Based off /tg/ code, with the modification that dropped items will appear on the vending machine instead of at the buyer's feet as not to conceal the bought item underneath the buyer themself.

## Why It's Good For The Game

Quickens the process of retrieving items from vending machines a bit, improving quality of life.

## Changelog
:cl:
add: Vending machines will now put vended items in available empty hands.
/:cl:
