### PR TITLE
Make firesuits be able to hold any internals tank.

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -18,7 +18,7 @@
 	gas_transfer_coefficient = 0.9
 	permeability_coefficient = 0.5
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/extinguisher, /obj/item/crowbar, /obj/item/powertool/jaws_of_life)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/extinguisher, /obj/item/crowbar, /obj/item/powertool/jaws_of_life) //ACULASTATION CHANGE: Firesuits can hold any internals tank.
 	slowdown = 1
 	armor = list("melee" = 15, "bullet" = 5, "laser" = 20, "energy" = 10, "bomb" = 20, "bio" = 10, "rad" = 20, "fire" = 100, "acid" = 50, "stamina" = 10)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT


### PR DESCRIPTION
## About The Pull Request

TItle. Firesuits can now hold any internals tanks in suit storage, including the larger oxygen tanks that they come with in fire lockers.

## Why It's Good For The Game

Makes using equipment from fire lockers more convenient, as you don't have to sacrifice your backpack to use the oxygen tank that comes with firesuits.

## Changelog
:cl:
tweak: Firesuits can now fit any internals tank, not just small emergency ones.
/:cl:
