### PR TITLE
Emergency maintenance access now automatically activates during radiation storms.

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -27,7 +27,7 @@
 /datum/weather/rad_storm/telegraph()
 	..()
 	status_alarm(TRUE)
-
+	make_maint_all_access() //ACULASTATION CHANGE
 
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	var/resist = L.getarmor(null, "rad")
@@ -50,6 +50,7 @@
 		return
 	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())
 	status_alarm(FALSE)
+	revoke_maint_all_access() //ACULASTATION CHANGE
 
 /datum/weather/rad_storm/proc/status_alarm(active)	//Makes the status displays show the radiation warning for those who missed the announcement.
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -27,7 +27,7 @@
 /datum/weather/rad_storm/telegraph()
 	..()
 	status_alarm(TRUE)
-	make_maint_all_access() //ACULASTATION CHANGE
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/make_maint_all_access), 5 SECONDS) //ACULASTATION CHANGE: Automatically enable emergency maint access during radstorm.
 
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	var/resist = L.getarmor(null, "rad")
@@ -50,7 +50,7 @@
 		return
 	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())
 	status_alarm(FALSE)
-	revoke_maint_all_access() //ACULASTATION CHANGE
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/revoke_maint_all_access), 1 MINUTES) //ACULASTATION CHANGE: Automatically enable emergency maint access during radstorm.
 
 /datum/weather/rad_storm/proc/status_alarm(active)	//Makes the status displays show the radiation warning for those who missed the announcement.
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -23,11 +23,18 @@
 	target_trait = ZTRAIT_STATION
 
 	immunity_type = "rad"
+	var/manual_emergency = FALSE
 
 /datum/weather/rad_storm/telegraph()
 	..()
 	status_alarm(TRUE)
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/make_maint_all_access), 5 SECONDS) //ACULASTATION CHANGE: Automatically enable emergency maint access during radstorm.
+	//ACULASTATION CHANGES START: Automatically enable emergency maint access during radstorm.
+	if(!GLOB.emergency_access)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/make_maint_all_access), 5 SECONDS)
+	else
+		manual_emergency = TRUE
+	//ACULASTATION CHANGES END
+	
 
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	var/resist = L.getarmor(null, "rad")
@@ -50,7 +57,12 @@
 		return
 	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())
 	status_alarm(FALSE)
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/revoke_maint_all_access), 1 MINUTES) //ACULASTATION CHANGE: Automatically enable emergency maint access during radstorm.
+	//ACULASTATION CHANGES START: Automatically enable emergency maint access during radstorm.
+	if(!manual_emergency)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/revoke_maint_all_access), 1 MINUTES)
+	else
+		return ..()
+	//ACULASTATION CHANGES END
 
 /datum/weather/rad_storm/proc/status_alarm(active)	//Makes the status displays show the radiation warning for those who missed the announcement.
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)


### PR DESCRIPTION
## About The Pull Request

Makes emergency maintenance access automatically activate when the radiation storm event occurs. It will also automatically be disabled once the storm subsides after a minute so that people can have a good amount of time to leave maint. Thanks to Mr Melbert for helping me with the timers!

## Why It's Good For The Game

Only a few jobs have bridge access by default, and these jobs won't always be taken or be available to give emergency maint access. This change makes it so crews, particularly lower population ones, have a better chance of survival if no one with bridge access is available to help.

## Changelog
:cl:
add: Emergency maintenance access will now automatically be enabled in response to radiation storms.
/:cl:
